### PR TITLE
indexJS: Change --smart syntax for pandoc 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ var pandocRenderer = function(data, options, callback){
     }
   }
 
-	var args = [ '-f', 'markdown', '-t', 'html', math, '--smart']
+	var args = [ '-f', 'markdown+smart', '-t', 'html', math]
   .concat(filters)
   .concat(extra)
   .concat(meta);


### PR DESCRIPTION
As described by the error log here:

```bash
Unhandled rejection Error: pandoc exited with code 2: --smart/-S has been removed.  Use +smart or -smart extension instead.
For example: pandoc -f markdown+smart -t markdown-smart.
Try pandoc --help for more information.

    at ChildProcess.<anonymous> (/home/haozeke/Github/Pandoc/hexNotes/node_modules/hexo-renderer-pandoc/index.js:73:20)
    at emitTwo (events.js:125:13)
    at ChildProcess.emit (events.js:213:7)
    at maybeClose (internal/child_process.js:927:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:211:5)

```

fixes #11 