### PR TITLE
fix 'config undefined' error

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ var pandocRenderer = function(data, options, callback){
   .concat(extra)
   .concat(meta);
 	
-  if(config.template) args.push("--template=" + config.template);
+  if(config && config.template) args.push("--template=" + config.template);
 
 	var src = data.text.toString();
 


### PR DESCRIPTION
After updating to the latest version of hexo-renderer-pandoc, if I try to generate files using `hexo g` I encountered the error `TypeError: Cannot read property 'template' of undefined` (the same as [@sli1989's comment here](https://github.com/wzpan/hexo-renderer-pandoc/pull/14#commitcomment-26635988).

It's caused by an missing explicit pandoc configuration like:
```yml
pandoc:
  filters:
  extra:
  template:
  meta:
  mathEngine:
```
So I made the workaround by adding a null-checking before using `config.template`.