### PR TITLE
Fix pandoc >=2.0 syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ var pandocRenderer = function(data, options, callback){
     }
   }
 
-  var args = [ '-f', 'markdown'+extensions, '-t', 'html', math]
+  var args = [ '-f', 'markdown-smart', '-t', 'html-smart', math]
   .concat(filters)
   .concat(extra)
   .concat(meta);


### PR DESCRIPTION
Newer versions of pandoc are incompatible with the current (old) arguments that hexo-renderer-pandoc is sending to pandoc, which causes errors such as:

```
--smart/-S has been removed.  Use +smart or -smart extension instead.
For example: pandoc -f markdown+smart -t markdown-smart.
Try pandoc --help for more information.
Error: pandoc document conversion failed with error 2
```

This PR tries to fix it by sending the new argument "-smart" instead .