### PR TITLE
fixing `null` being passed as an argument to pandoc

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,8 +23,10 @@ var pandocRenderer = function(data, options, callback){
 	    var eoption = config.extra[e];
         for (var key in eoption){
           extra.push('--' + key);
-	        extra.push(eoption[key]); 
-	      }
+          if(eoption[key]!=null) {
+            extra.push(eoption[key]); 
+          }
+	}
       }
     }
 


### PR DESCRIPTION
When doing

``` yml
pandoc:
  # other options
  extra:
    - toc: # will be passed as `--toc`. Note the colon
  template: dir/../template.html
```

argument passed to pandoc is:

``` json
[ '-f',
  'markdown-smart',
  '-t',
  'html-smart',
  '--mathjax',
  '--toc',
  null,
  '--template=template.html' ]
```