### PR TITLE
remove a harmless warning message

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,6 +78,11 @@ var pandocRenderer = function(data, options, callback){
 		var msg = '';
 		if (code !== 0)
 			msg += 'pandoc exited with code '+code+(error ? ': ' : '.');
+		// remove this harmless warning message
+		// to prevent program from crashing
+		error = error.replace(
+			"[WARNING] This document format requires a nonempty <title> element.\r\n  Please specify either 'title' or 'pagetitle' in the metadata.\r\n  Falling back to 'Untitled'\r\n"
+		,'');
 		if (error)
 			msg += error;
 		if (msg)

--- a/index.js
+++ b/index.js
@@ -78,11 +78,14 @@ var pandocRenderer = function(data, options, callback){
 		var msg = '';
 		if (code !== 0)
 			msg += 'pandoc exited with code '+code+(error ? ': ' : '.');
-		// remove this harmless warning message
+		// remove these two harmless warning messages
 		// to prevent program from crashing
 		error = error.replace(
 			"[WARNING] This document format requires a nonempty <title> element.\r\n  Please specify either 'title' or 'pagetitle' in the metadata.\r\n  Falling back to 'Untitled'\r\n"
 		,'');
+		error = error.replace(
+			"[WARNING] This document format requires a nonempty <title> element.\r\n  Please specify either 'title' or 'pagetitle' in the metadata,\r\n  e.g. by using --metadata pagetitle=\"...\" on the command line.\r\n  Falling back to 'Untitled'\r\n"
+		,'')
 		if (error)
 			msg += error;
 		if (msg)


### PR DESCRIPTION
I encountered the following when generating the site using this plugin:

```
Error: [WARNING] This document format requires a nonempty <title> element.
  Please specify either 'title' or 'pagetitle' in the metadata.
  Falling back to 'Untitled'
```

What happened is that HTML5, and so does Pandoc, requires a title to be specified for the output.
The warning message is then caught on
[this line](https://github.com/wzpan/hexo-renderer-pandoc/blob/dd837a149e39045b64577a226c5e77c7c39927d9/index.js#L72).
It then propagates to
[this line](https://github.com/wzpan/hexo-renderer-pandoc/blob/dd837a149e39045b64577a226c5e77c7c39927d9/index.js#L82)
and triggered 
[this line](https://github.com/wzpan/hexo-renderer-pandoc/blob/dd837a149e39045b64577a226c5e77c7c39927d9/index.js#L84)
to issue the error.

The issue is that this warning is harmless and should not become an error. So I propose this solution.

I originally wanted to match the result on
[this line](https://github.com/wzpan/hexo-renderer-pandoc/blob/dd837a149e39045b64577a226c5e77c7c39927d9/index.js#L72)
to the warning message and filter it out, but turned out that one warning message can span multiple data events, i.e., it can be returned in pieces.
So I decided to wait until the very end to remove this particular warning message.

===

Added on Feb 5, 2019

I found a similar warning message.
This one replaced the previous one since https://github.com/jgm/pandoc/commit/f8879ee0a1f00bcf1ead9dce0576c381cbcae778#diff-d4eaae919c702ecf1769ce3a7548cc75

```
Error: [WARNING] This document format requires a nonempty <title> element.
  Please specify either 'title' or 'pagetitle' in the metadata,
  e.g. by using --metadata pagetitle=\"...\" on the command line.
  Falling back to 'Untitled'
```