### PR TITLE
add back extension capability

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ var pandocRenderer = function(data, options, callback){
     }
   }
 
-  var args = [ '-f', 'markdown-smart', '-t', 'html-smart', math]
+  var args = [ '-f', 'markdown-smart'+extensions, '-t', 'html-smart', math]
   .concat(filters)
   .concat(extra)
   .concat(meta);


### PR DESCRIPTION
Hi @wzpan @alexpnt ,

The commit https://github.com/wzpan/hexo-renderer-pandoc/commit/1747d9f3479eebd398568d623df6deae8615882d#diff-168726dbe96b3ce427e7fedce31bb0bc disabled the `smart` extension by default, which I understand.

But why remove the user specified extensions capability introduced in the previous commit https://github.com/wzpan/hexo-renderer-pandoc/commit/c0ec725baed03f225769fff9f957fd968aaf05a5#diff-168726dbe96b3ce427e7fedce31bb0bc ?

Further, if user specified extensions are intended to be removed indeed, then why line 8-13 in the above stated commit have not been removed too?

This pull request restores that capability.