### PR TITLE
:bug: fix #50: add `--wrap=none` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ var pandocRenderer = function(data, options){
     }
   }
 
-  var args = [ '-f', 'markdown-smart'+extensions, '-t', 'html-smart', math]
+  var args = [ '-f', 'markdown-smart'+extensions, '-t', 'html-smart', math, "--wrap=none"]
   .concat(filters)
   .concat(extra)
   .concat(meta);


### PR DESCRIPTION
Please read the problem description in <https://github.com/hexojs/hexo-renderer-pandoc/issues/50>

Reason for this PR: <https://github.com/hexojs/hexo-generator-feed/pull/198#issuecomment-1493268825>

Adding the `--wrap=none` option to Pandoc does not seem to affect normal HTML rendering, and does not add redundant `\r\n` to the converted HTML.