### PR TITLE
fix: correct repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,7 @@
   "bugs": {
     "url": "https://github.com/hexojs/hexo-renderer-pandoc/issues"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/hexojs/hexo-renderer-pandoc/.git"
-  },
+  "repository": "github:hexojs/hexo-renderer-pandoc",
   "author": {
     "name": "Joseph Pan",
     "email": "cs.wzpan@gmail.com",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "bugs": {
     "url": "https://github.com/hexojs/hexo-renderer-pandoc/issues"
   },
-  "repository": "github:hexojs/hexo-renderer-pandoc",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hexojs/hexo-renderer-pandoc.git"
+  },
   "author": {
     "name": "Joseph Pan",
     "email": "cs.wzpan@gmail.com",


### PR DESCRIPTION
## check list

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.

## Description

The repository URL in package.json was incorrectly formatted with a trailing `.git` separated by a slash. This caused the "Repository" link on the npmjs.com page to point to an invalid URL, leading to a 404 error when clicked.

Additionally, I've updated the field to use the modern shorthand syntax.
